### PR TITLE
Show how running d1 command generates a duplicate D1 binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,38 +63,55 @@ Your Cloudflare account needs access to Workers for Platforms and D1.
    npm install
    ```
 
-2. Create a D1 database and copy the ID into `wrangler.jsonc`. Make sure you update the `database_id` in wrangler.jsonc for your D1 binding afterwards:
+2. Create an API token with Workers Scripts (Edit) permission:
+
+   Visit [https://dash.cloudflare.com/?to=/:account/api-tokens](https://dash.cloudflare.com/?to=/:account/api-tokens) and create a new token with the "Workers Scripts (Edit)" permission.
+
+3. Copy the `.env.test` file to `.env` and set the `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets:
+
+   ```sh
+   cp .env.test .env
+   ```
+
+   Then edit the `.env` file with your actual values:
+
+   ```sh
+   CLOUDFLARE_ACCOUNT_ID = "your_actual_account_id"
+   CLOUDFLARE_API_TOKEN = "your_actual_api_token"
+   ```
+
+   The `.env` file is already in `.gitignore` and will not be committed to git.
+
+  Then run the following commands to add these secrets to your Worker in production:
+
+  ```
+  npx wrangler@latest secret put CLOUDFLARE_API_TOKEN
+  ```
+
+  ```
+  npx wrangler@latest secret put CLOUDFLARE_ACCOUNT_ID
+  ```
+
+4. Create a D1 database and copy the ID into `wrangler.jsonc`. Make sure you update the `database_id` in wrangler.jsonc for your D1 binding afterwards:
 
    ```
    npx wrangler d1 create workers-for-platforms-example-project
    ```
 
-3. Edit the `vars` in `wrangler.jsonc` and set the `CLOUDFLARE_API_TOKEN` secret (instructions in `wrangler.jsonc`).
-   For local development, you also have to create a `.dev.vars` file with the same environment variables:
-
-   ```sh
-   CLOUDFLARE_ACCOUNT_ID = "replace_me"
-   CLOUDFLARE_API_TOKEN = "replace_me"
-   ```
-
-   > To create an API Token, go to Workers dashboard -> click "API Tokens" on right sidebar. Then either:
-   > 1. Click "API Tokens" on the right sidebar.
-   > 2. Click "Create Token". Make sure you give this token at least "Account : Workers Scripts : Edit". This token is used with `Bearer`.
-
-4. Create a namespace. Replace `$(ACCOUNT)`, `$(API_TOKEN)`, and `$(NAMESPACE)`:
+5. Create a namespace. Replace `$(ACCOUNT)`, `$(API_TOKEN)`, and `$(NAMESPACE)`:
    ```
    npx wrangler dispatch-namespace create workers-for-platforms-example-project
    ```
 
-5. Run the Worker in dev mode:
+6. Run the Worker in dev mode:
    ```
-   npx wrangler dev --remote # local dev not currently supported
+   npm run dev
    ```
    Or deploy to production:
    ```
-   npx wrangler deploy
+   npm run deploy
    ```
-   > Dev mode will still use the configured dispatch namespace. Take care you're not accidentally modifying production!
+   > Dev mode uses remote bindings to connect to your deployed D1 database and dispatch namespace. Take care you're not accidentally modifying production data!
 
 Once the Worker is live, visit [localhost:8787](http://localhost:8787/) in a browser and click the `Initialize` link. Have fun!
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,19 +5,16 @@
 	"dispatch_namespaces": [
 		{
 			"binding": "dispatcher",
-			"namespace": "workers-for-platforms-example-project" // make sure this is the same value as DISPATCH_NAMESPACE_NAME
+			"namespace": "workers-for-platforms-example-project", // make sure this is the same value as DISPATCH_NAMESPACE_NAME
+			"remote": true
 		}
 	],
 	"d1_databases": [
 		{
 			"binding": "workers_for_platforms_example_project",
 			"database_name": "workers-for-platforms-example-project",
-			"database_id": ""
-		},
-		{
-			"binding": "workers_for_platforms_example_project",
-			"database_name": "workers-for-platforms-example-project",
-			"database_id": "c24ad881-6061-4a1b-b83f-d2199ea92a02"
+			"database_id": "c24ad881-6061-4a1b-b83f-d2199ea92a02",
+			"remote": true
 		}
 	],
 	"vars": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,6 +13,11 @@
 			"binding": "workers_for_platforms_example_project",
 			"database_name": "workers-for-platforms-example-project",
 			"database_id": ""
+		},
+		{
+			"binding": "workers_for_platforms_example_project",
+			"database_name": "workers-for-platforms-example-project",
+			"database_id": "c24ad881-6061-4a1b-b83f-d2199ea92a02"
 		}
 	],
 	"vars": {


### PR DESCRIPTION
How to repro:

run:

```
npx wrangler d1 create workers-for-platforms-example-project
```

From this branch:

https://github.com/cloudflare/workers-for-platforms-example/pull/42

Observe that even though there is already a binding for the D1 DB with that name, we add an additional one to the `wrangler.jsonc`

Probably means that instead of including the placeholder, we should just not have it in `wrangler.jsonc` and expect someone to run the command?

Kind of have to pick, otherwise confusing